### PR TITLE
HTTP_CODES and status texts from Symfony Response class

### DIFF
--- a/app/Http/Controllers/LinksController.php
+++ b/app/Http/Controllers/LinksController.php
@@ -6,6 +6,7 @@ use App\Link;
 use App\Transformers\LinkTransformer;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 
 class LinksController extends Controller
 {
@@ -30,7 +31,7 @@ class LinksController extends Controller
 
         return response()->json(
             $this->item($link, new LinkTransformer()),
-            201,
+            Response::HTTP_CREATED,
             ['Location' => route('links.show', ['id' => $link->id])]
         );
     }
@@ -56,6 +57,6 @@ class LinksController extends Controller
 
         $link->delete();
 
-        return response(null, 204);
+        return response(null, Response::HTTP_NO_CONTENT);
     }
 }

--- a/tests/features/CreateLinkTest.php
+++ b/tests/features/CreateLinkTest.php
@@ -32,7 +32,7 @@ class CreateLinkTest extends TestCase
             ], ['Accept' => 'application/json']);
 
         $this
-            ->seeStatusCode(201)
+            ->seeStatusCode(Response::HTTP_CREATED)
             ->seeHeaderWithRegExp('Location', '#/links/[\d]+$#');
         
         $body = json_decode($this->response->getContent(), true);

--- a/tests/features/DeleteLinkTest.php
+++ b/tests/features/DeleteLinkTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Http\Response;
 use Laravel\Lumen\Testing\DatabaseMigrations;
 
 class DeleteLinkTest extends TestCase
@@ -22,7 +23,7 @@ class DeleteLinkTest extends TestCase
 
         $this
             ->delete("/links/{$link->id}", [], ['Accept' => 'application/json'])
-            ->seeStatusCode(204)
+            ->seeStatusCode(Response::HTTP_NO_CONTENT)
             ->isEmpty();
 
         $this->notSeeInDatabase('links', ['id' => $link->id]);
@@ -32,11 +33,11 @@ class DeleteLinkTest extends TestCase
     {
         $this
             ->delete('links/999', [], ['Accept' => 'application/json'])
-            ->seeStatusCode(404)
+            ->seeStatusCode(Response::HTTP_NOT_FOUND)
             ->seeJson([
                 'error' => [
-                    'message' => 'Not Found',
-                    'status' => 404,
+                    'message' => Response::$statusTexts[Response::HTTP_NOT_FOUND],
+                    'status' => Response::HTTP_NOT_FOUND,
                 ],
             ]);
     }

--- a/tests/features/GetLinkTest.php
+++ b/tests/features/GetLinkTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Http\Response;
 use Laravel\Lumen\Testing\DatabaseMigrations;
 
 class GetLinkTest extends TestCase
@@ -12,7 +13,7 @@ class GetLinkTest extends TestCase
 
         $this
             ->get("/links/{$link->id}", ['Accept' => 'application/json'])
-            ->seeStatusCode(200);
+            ->seeStatusCode(Response::HTTP_OK);
 
         $body = json_decode($this->response->getContent(), true);
         $this->assertArrayHasKey('data', $body);
@@ -30,11 +31,11 @@ class GetLinkTest extends TestCase
     {
         $this
             ->get('links/999', ['Accept' => 'application/json'])
-            ->seeStatusCode(404)
+            ->seeStatusCode(Response::HTTP_NOT_FOUND)
             ->seeJson([
                 'error' => [
-                    'message' => 'Not Found',
-                    'status' => 404,
+                    'message' => Response::$statusTexts[Response::HTTP_NOT_FOUND],
+                    'status' => Response::HTTP_NOT_FOUND,
                 ],
             ]);
     }

--- a/tests/features/GetLinksTest.php
+++ b/tests/features/GetLinksTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Http\Response;
 use Laravel\Lumen\Testing\DatabaseMigrations;
 
 class GetLinksTest extends TestCase
@@ -12,7 +13,7 @@ class GetLinksTest extends TestCase
 
         $this
             ->get('/links', ['Accept' => 'application/json'])
-            ->seeStatusCode(200);
+            ->seeStatusCode(Response::HTTP_OK);
 
         $body = json_decode($this->response->getContent(), true);
         $this->assertArrayHasKey('data', $body);

--- a/tests/features/UpdateLinkTest.php
+++ b/tests/features/UpdateLinkTest.php
@@ -40,7 +40,7 @@ class UpdateLinkTest extends TestCase
             ], ['Accept' => 'application/json']);
 
         $this
-            ->seeStatusCode(200)
+            ->seeStatusCode(Response::HTTP_OK)
             ->seeJson([
                 'id' => $link->id,
                 'title' => 'Links app',
@@ -65,11 +65,11 @@ class UpdateLinkTest extends TestCase
     {
         $this
             ->put('links/999', [], ['Accept' => 'application/json'])
-            ->seeStatusCode(404)
+            ->seeStatusCode(Response::HTTP_NOT_FOUND)
             ->seeJson([
                 'error' => [
-                    'message' => 'Not Found',
-                    'status' => 404,
+                    'message' => Response::$statusTexts[Response::HTTP_NOT_FOUND],
+                    'status' => Response::HTTP_NOT_FOUND,
                 ],
             ]);
     }
@@ -92,7 +92,10 @@ class UpdateLinkTest extends TestCase
 
         $this->put("/links/{$link->id}", [], ['Accept' => 'application/json']);
         
-        $this->assertEquals(Response::HTTP_UNPROCESSABLE_ENTITY, $this->response->getStatusCode());
+        $this->assertEquals(
+            Response::HTTP_UNPROCESSABLE_ENTITY,
+            $this->response->getStatusCode()
+        );
 
         $body = json_decode($this->response->getContent(), true);
 

--- a/tests/unit/HandlerTest.php
+++ b/tests/unit/HandlerTest.php
@@ -2,8 +2,9 @@
 
 use App\Exceptions\Handler;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
-use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 use Laravel\Lumen\Testing\DatabaseTransactions;
 use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
@@ -52,7 +53,7 @@ class HandlerTest extends TestCase
         $this->assertArrayHasKey('message', $error);
         $this->assertArrayHasKey('status', $error);
         $this->assertEquals('Error', $error['message']);
-        $this->assertEquals(400, $error['status']);
+        $this->assertEquals(Response::HTTP_BAD_REQUEST, $error['status']);
     }
 
     public function test_it_responds_with_json_responses_for_http_exceptions()
@@ -66,18 +67,18 @@ class HandlerTest extends TestCase
         $exceptions = [
             [
                 'mock' => AccessDeniedHttpException::class,
-                'message' => 'Forbidden',
-                'status' => 403,
+                'message' => Response::$statusTexts[Response::HTTP_FORBIDDEN],
+                'status' => Response::HTTP_FORBIDDEN,
             ],
             [
                 'mock' => NotFoundHttpException::class,
-                'message' => 'Not Found',
-                'status' => 404,
+                'message' => Response::$statusTexts[Response::HTTP_NOT_FOUND],
+                'status' => Response::HTTP_NOT_FOUND,
             ],
             [
                 'mock' => ModelNotFoundException::class,
-                'message' => 'Not Found',
-                'status' => 404,
+                'message' => Response::$statusTexts[Response::HTTP_NOT_FOUND],
+                'status' => Response::HTTP_NOT_FOUND,
             ],
         ];
 


### PR DESCRIPTION
Refactor to use HTTP_CODES constants and status texts from class Symfony\Component\HttpFoundation\Response
